### PR TITLE
Link to new Libraries page

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,4 @@ Not implemented: WAC, WebID-RSA, or WebID-Delegation.
 
 ## Libraries
 
-### Node.js
-* [node-webid](https://github.com/linkeddata/node-webid/) - library to manage
-    [WebID](http://www.w3.org/2005/Incubator/webid/spec/identity/) identities
-    and certificates.
-
-* [rdflib.js](https://github.com/linkeddata/rdflib.js/) - RDF library for
-    [Linked Data](http://www.w3.org/DesignIssues/LinkedData.html) applications.
-
-* [solid.js](https://github.com/solid/solid.js) - library to interact with
-    [Solid](https://github.com/solid/solid-spec)-compliant applications.
-    Creates and manages LDP containers, provides WebID authentication, and more.
+See https://solid.github.io/for-developers/apps/tools


### PR DESCRIPTION
once updated, we can change 'solid.github.io' to 'solidproject.org', but with this, at least we're already pointing to a single place and no longer have a risk that libraries would be added here and not there.

Depends on solid/solid.github.io#191